### PR TITLE
Refactor merkato startup method

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -78,6 +78,7 @@ class Bot(ttk.Frame):
             self.name = persist["coin"] + "/" + persist["base"] + "    " + persist["configuration"]["exchange"]
             self.title_var.set(str(self.name))
             self.bot = Merkato(**persist) #presumably from db
+            self.bot.startup()
 
         # --------------------
         self.exchange_frame = ttk.Frame(self, style="app.TFrame")
@@ -168,6 +169,7 @@ class Bot(ttk.Frame):
         if not self.stub:
             try:
               self.bot = Merkato(**self.merk_args)
+              self.bot.startup()
             except Exception as e:
                 e2 = traceback.format_exc()
                 safe_show = self.merk_args.copy()

--- a/db_init_script.py
+++ b/db_init_script.py
@@ -46,6 +46,7 @@ def main():
         return False
 
     merkato = Merkato(configuration, coin, base, spread, base_reserve, coin_reserve)
+    merkato.startup()
     context = merkato.update()
     print('context', context)
     visualize_orderbook(context["orderbook"])


### PR DESCRIPTION
I believe decoupling init of the merkato object (which basically just validates & assigns parameters) and startup (when we start actually placing orders and stuff) will make interoperability with whatever UI solution we use easier, in the long run.